### PR TITLE
Removed obsolete updateStateOfVertex

### DIFF
--- a/src/main/scala/com/signalcollect/interfaces/Storage.scala
+++ b/src/main/scala/com/signalcollect/interfaces/Storage.scala
@@ -40,7 +40,6 @@ trait VertexStore {
   def getAll(condition: Vertex[_, _] => Boolean): List[Vertex[_, _]]
   def put(vertex: Vertex[_, _]): Boolean
   def remove(id: Any)
-  def updateStateOfVertex(vertex: Vertex[_, _])
   def size: Long
   def foreach[U](f: Vertex[_, _] => U)
   def cleanUp
@@ -56,7 +55,6 @@ trait VertexIdSet {
   def isEmpty: Boolean
   def foreach[U](f: Any => U, removeAfterProcessing: Boolean)
   def applyToNext[U](f: (Any) => U, removeAfterProcessing: Boolean)
-  def updateStateOfVertex(vertex: Vertex[_, _])
   def cleanUp
 }
 

--- a/src/main/scala/com/signalcollect/storage/InMemoryStorage.scala
+++ b/src/main/scala/com/signalcollect/storage/InMemoryStorage.scala
@@ -82,17 +82,11 @@ class InMemoryStorage(storage: Storage) extends VertexStore {
     storage.toSignal.remove(id)
   }
 
-
   /**
-   * Is not needed for this implementation because the state does not need to be retained, since the objects are passed by reference and changes
-   * in the vertex's state are reflected immediately.
-   *
-   * @param vertex the vertex that would have to be updated
+   * Applies the supplied function to each stored vertex
+   * 
+   * @param f Function to apply to each stored vertex
    */
-  def updateStateOfVertex(vertex: Vertex[_, _]) = {
-    storage.toSignal.updateStateOfVertex(vertex)
-  }
-
   def foreach[U](f: Vertex[_, _] => U) {
     val it = vertexMap.values.iterator
     while (it.hasNext) {

--- a/src/main/scala/com/signalcollect/worker/AkkaWorker.scala
+++ b/src/main/scala/com/signalcollect/worker/AkkaWorker.scala
@@ -198,7 +198,6 @@ class AkkaWorker(val workerId: Int,
         counters.outgoingEdgesAdded += 1
         vertexStore.toCollect.addVertex(vertex.id)
         vertexStore.toSignal.add(vertex.id)
-        vertexStore.vertices.updateStateOfVertex(vertex)
       }
     } else {
       warning("Did not find vertex with id " + sourceId + " when trying to add outgoing edge (" + sourceId + ", " + edge.targetId + ")")
@@ -220,7 +219,6 @@ class AkkaWorker(val workerId: Int,
         counters.outgoingEdgesRemoved += 1
         vertexStore.toCollect.addVertex(vertex.id)
         vertexStore.toSignal.add(vertex.id)
-        vertexStore.vertices.updateStateOfVertex(vertex)
       } else {
         warning("Outgoing edge not found when trying to remove edge with id " + edgeId)
       }
@@ -287,7 +285,6 @@ class AkkaWorker(val workerId: Int,
     val vertex = vertexStore.vertices.get(vertexId)
     if (vertex != null) {
       val result = f(vertex.asInstanceOf[VertexType])
-      vertexStore.vertices.updateStateOfVertex(vertex)
       result
     } else {
       throw new Exception("Vertex with id " + vertexId + " not found.")
@@ -391,7 +388,6 @@ class AkkaWorker(val workerId: Int,
         try {
           counters.collectOperationsExecuted += 1
           vertex.executeCollectOperation(uncollectedSignalsList, graphEditor)
-          vertexStore.vertices.updateStateOfVertex(vertex)
           hasCollected = true
           if (addToSignal && vertex.scoreSignal > signalThreshold) {
             vertexStore.toSignal.add(vertex.id)
@@ -414,7 +410,6 @@ class AkkaWorker(val workerId: Int,
         try {
           vertex.executeSignalOperation(graphEditor)
           counters.signalOperationsExecuted += 1
-          vertexStore.vertices.updateStateOfVertex(vertex)
           hasSignaled = true
         } catch {
           case t: Throwable => severe(t)


### PR DESCRIPTION
This method was only needed to serialize the changed vertex's state
back to disk.
