### PR TITLE
Moved to Scala 2.10.0-RC2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-actor_2.10.0-M7</artifactId>
+			<artifactId>akka-actor_2.10.0-RC2</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-remote_2.10.0-M7</artifactId>
+			<artifactId>akka-remote_2.10.0-RC2</artifactId>
 			<version>${akka.version}</version>
 		</dependency>
 		<dependency>
@@ -63,8 +63,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.specs2</groupId>
-			<artifactId>specs2_2.10.0-M7</artifactId>
-			<version>1.12.1.1</version>
+			<artifactId>specs2_2.10.0-RC2</artifactId>
+			<version>1.12.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -181,8 +181,8 @@
 		<project.reporting.outputEncoding>
 			UTF-8
 		</project.reporting.outputEncoding>
-		<scala.version>2.10.0-M7</scala.version>
-		<akka.version>2.1-M2</akka.version>
+		<scala.version>2.10.0-RC2</scala.version>
+		<akka.version>2.1.0-RC2</akka.version>
 		<maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
 	</properties>
 </project>

--- a/src/main/scala/com/signalcollect/DefaultGraph.scala
+++ b/src/main/scala/com/signalcollect/DefaultGraph.scala
@@ -23,11 +23,10 @@ import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.actor.ReceiveTimeout
-import scala.concurrent.util.Duration._
-import scala.concurrent.util.Duration
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration
 import com.signalcollect.configuration.TerminationReason
 import com.sun.management.OperatingSystemMXBean
-import scala.concurrent.util.Duration._
 import scala.concurrent.Await
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
@@ -46,7 +45,7 @@ import com.signalcollect.configuration._
 import com.signalcollect.coordinator._
 import com.signalcollect.messaging._
 import com.signalcollect.logging.DefaultLogger
-import scala.concurrent.util.FiniteDuration
+import scala.concurrent.duration.FiniteDuration
 import com.signalcollect.interfaces.Coordinator
 
 /**

--- a/src/main/scala/com/signalcollect/ExecutionConfiguration.scala
+++ b/src/main/scala/com/signalcollect/ExecutionConfiguration.scala
@@ -21,7 +21,7 @@ package com.signalcollect
 
 import com.signalcollect.interfaces._
 import com.signalcollect.configuration.ExecutionMode
-import scala.concurrent.util.Duration
+import scala.concurrent.duration.Duration
 
 /**
  *  An execution configuration specifies execution parameters for a computation. This object

--- a/src/main/scala/com/signalcollect/ExecutionInformation.scala
+++ b/src/main/scala/com/signalcollect/ExecutionInformation.scala
@@ -22,8 +22,8 @@ package com.signalcollect
 import com.signalcollect.interfaces._
 import com.signalcollect.configuration._
 import com.signalcollect.configuration.TerminationReason
-import scala.concurrent.util.Duration._
-import scala.concurrent.util.Duration
+import scala.concurrent.duration._
+import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
 
 /**

--- a/src/main/scala/com/signalcollect/coordinator/DefaultCoordinator.scala
+++ b/src/main/scala/com/signalcollect/coordinator/DefaultCoordinator.scala
@@ -36,7 +36,7 @@ import java.util.{ HashMap, Map }
 import scala.collection.JavaConversions._
 import akka.actor.ReceiveTimeout
 import java.util.concurrent.TimeUnit
-import scala.concurrent.util.Duration._
+import scala.concurrent.duration._
 import akka.actor.ActorLogging
 import akka.event.LoggingReceive
 import com.signalcollect.messaging.Request

--- a/src/main/scala/com/signalcollect/messaging/AkkaProxy.scala
+++ b/src/main/scala/com/signalcollect/messaging/AkkaProxy.scala
@@ -27,8 +27,8 @@ import com.signalcollect.interfaces._
 import java.lang.reflect.Method
 import akka.actor.ActorRef
 import akka.util.Timeout
-import scala.concurrent.util.Duration
-import scala.concurrent.util.Duration._
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import java.util.concurrent.atomic.AtomicLong

--- a/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeControllerActor.scala
+++ b/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeControllerActor.scala
@@ -41,8 +41,8 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import scala.concurrent.util.Duration
-import scala.concurrent.util.Duration._
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.Await

--- a/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeProvisionerActor.scala
+++ b/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeProvisionerActor.scala
@@ -41,8 +41,8 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import scala.concurrent.util.Duration
-import scala.concurrent.util.Duration._
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.Await

--- a/src/main/scala/com/signalcollect/nodeprovisioning/torque/TorqueNodeProvisioner.scala
+++ b/src/main/scala/com/signalcollect/nodeprovisioning/torque/TorqueNodeProvisioner.scala
@@ -41,8 +41,8 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import scala.concurrent.util.Duration
-import scala.concurrent.util.Duration._
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.Await

--- a/src/main/scala/com/signalcollect/worker/AkkaWorker.scala
+++ b/src/main/scala/com/signalcollect/worker/AkkaWorker.scala
@@ -34,7 +34,7 @@ import java.util.Map
 import java.util.Set
 import com.signalcollect._
 import com.signalcollect.serialization.DefaultSerializer
-import concurrent.util.duration._
+import concurrent.duration._
 import akka.actor.PoisonPill
 import akka.actor.ReceiveTimeout
 import akka.actor.ActorRef


### PR DESCRIPTION
Hi, 

I am trying to start working with Signal Collect framework. In order to do that, I have setup a eclipse environment and I have tried getting the signal-collect project into eclipse from git via Maven SCM import for scala IDE. There is a small problem with the pom.xml since no source or testSource directories appear.  I have included them. 

On the other hand, Scala IDE relies on Scala 2.10.0-RC2. Duration place has moved out of scala.concurrent.util. I have changed the files so that they compile. I have also changed the Akka and specs2 dependencies in the pom.xml file. Everything runs nicely with these changes.

Let me know if this is of any use.

Jesús   
