### PR TITLE
Removed superfluous println in the SudokuHelper

### DIFF
--- a/src/main/scala/com/signalcollect/examples/Sudoku.scala
+++ b/src/main/scala/com/signalcollect/examples/Sudoku.scala
@@ -226,7 +226,6 @@ object SudokuHelper {
   //All possible numbers for a cell
   val legalNumbers = {
     var numbers = (1 to 9).toSet
-    println
     numbers
   }
 


### PR DESCRIPTION
That insignificant println caused the annoying switch from the JUnit view to the Console view when running the tests in Eclipse.
