### PR TITLE
NodeProvisionerActor expects now a proper NodeReady message and not a String

### DIFF
--- a/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeProvisionerActor.scala
+++ b/src/main/scala/com/signalcollect/nodeprovisioning/torque/NodeProvisionerActor.scala
@@ -24,6 +24,7 @@ import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.PoisonPill
 import akka.actor.actorRef2Scala
+import com.signalcollect.interfaces.NodeReady
 
 class NodeProvisionerActor(numberOfNodes: Int) extends Actor {
 
@@ -35,7 +36,7 @@ class NodeProvisionerActor(numberOfNodes: Int) extends Actor {
     case "GetNodes" =>
       nodeListRequestor = Some(sender)
       sendNodesIfReady
-    case "NodeReady" =>
+    case NodeReady =>
       nodeControllers = sender :: nodeControllers
       sendNodesIfReady
   }


### PR DESCRIPTION
Caused the distributed version to hang.
