### PR TITLE
Corrected a mistake in the method AbstractMessageBus.sendToNode

### DIFF
--- a/src/main/scala/com/signalcollect/messaging/AbstractMessageBus.scala
+++ b/src/main/scala/com/signalcollect/messaging/AbstractMessageBus.scala
@@ -170,7 +170,7 @@ trait AbstractMessageBus[@specialized(Int, Long) Id, @specialized(Int, Long, Flo
 
   override def sendToNode(nodeId: Int, message: Any) {
     incrementMessagesSentToNode(nodeId)
-    workers(nodeId) ! message
+    nodes(nodeId) ! message
   }
 
   override def sendToNodes(message: Any, messageCounting: Boolean) {


### PR DESCRIPTION
AbstractMessageBus.sendToNode now sends messages to nodes and not to workers.
